### PR TITLE
Add compatibility with WHMCS 8.1

### DIFF
--- a/modules/addons/disable_languages/hooks.php
+++ b/modules/addons/disable_languages/hooks.php
@@ -6,7 +6,7 @@ add_hook( 'ClientAreaPage', 1, function( array $vars ) {
     $getEnabled = Capsule::table( 'mod_disable_languages' )->first();
     $enabled = json_decode( $getEnabled->enabled );
 
-    $locales = $vars['locales'];
+    $locales = &$vars['locales'];
     foreach ( $locales as $key => $locale ) { 
         if ( ! in_array( $locale['language'], $enabled ) ) {
             unset( $locales[$key] ); 


### PR DESCRIPTION
The module was not working for me in WHMCS 8.1 until I assigned a reference to the the $locales variable so that it also gets unset in the $vars returned to WHMCS.